### PR TITLE
NumPad now restores the former num lock state on deactivation.

### DIFF
--- a/src/Kaleidoscope-NumPad.cpp
+++ b/src/Kaleidoscope-NumPad.cpp
@@ -6,10 +6,12 @@
 byte NumPad_::row = 255, NumPad_::col = 255;
 uint8_t NumPad_::numPadLayer;
 bool NumPad_::cleanupDone = true;
+bool NumPad_::originalNumLockState = false;
 cRGB numpad_color = CRGB(255, 0, 0);
 
 void NumPad_::begin(void) {
   Kaleidoscope.useLoopHook(loopHook);
+  originalNumLockState = !!(kaleidoscope::hid::getKeyboardLEDs() & LED_NUM_LOCK);
 }
 
 void NumPad_::loopHook(bool postClear) {
@@ -17,10 +19,17 @@ void NumPad_::loopHook(bool postClear) {
     return;
 
   if (!Layer.isOn(numPadLayer)) {
+    bool numState = !!(kaleidoscope::hid::getKeyboardLEDs() & LED_NUM_LOCK);
     if (!cleanupDone) {
       LEDControl.set_mode(LEDControl.get_mode_index());
       cleanupDone = true;
+
+      if (numState && !originalNumLockState) {
+        kaleidoscope::hid::pressKey(Key_KeypadNumLock);
+        numState = false;
+      }
     }
+    originalNumLockState = numState;
     return;
   }
 

--- a/src/Kaleidoscope-NumPad.h
+++ b/src/Kaleidoscope-NumPad.h
@@ -17,6 +17,7 @@ class NumPad_ : public KaleidoscopePlugin {
 
   static byte row, col;
   static bool cleanupDone;
+  static bool originalNumLockState;
 };
 
 extern NumPad_ NumPad;


### PR DESCRIPTION
this resolves https://github.com/keyboardio/Kaleidoscope-NumPad/issues/1