### PR TITLE
Don't enable LED on Key_NoKey

### DIFF
--- a/src/Kaleidoscope-NumPad.cpp
+++ b/src/Kaleidoscope-NumPad.cpp
@@ -42,7 +42,7 @@ void NumPad_::loopHook(bool postClear) {
         col = c;
       }
 
-      if ((k != layer_key) || (k.flags != KEY_FLAGS)) {
+      if ((k != layer_key) || (k == Key_NoKey) || (k.flags != KEY_FLAGS)) {
         LEDControl.refreshAt(r, c);
       } else {
         LEDControl.setCrgbAt(r, c, numpad_color);


### PR DESCRIPTION
Currently, when numpad layer is on, LED are enabled on XXX keys.
I think it's not what we want.