### PR TITLE
Numpad now properly restores the former numlock state on deactivation.

### DIFF
--- a/src/Kaleidoscope-NumPad.cpp
+++ b/src/Kaleidoscope-NumPad.cpp
@@ -14,8 +14,12 @@ void NumPad_::begin(void) {
   originalNumLockState = !!(kaleidoscope::hid::getKeyboardLEDs() & LED_NUM_LOCK);
 }
 
+static bool getNumlockState() {
+  return !!(kaleidoscope::hid::getKeyboardLEDs() & LED_NUM_LOCK);
+}
+
 static void syncNumlock(bool state) {
-  bool numState = !!(kaleidoscope::hid::getKeyboardLEDs() & LED_NUM_LOCK);
+  bool numState = getNumlockState();
   if (numState != state) {
     kaleidoscope::hid::pressKey(Key_KeypadNumLock);
   }
@@ -26,16 +30,15 @@ void NumPad_::loopHook(bool postClear) {
     return;
 
   if (!Layer.isOn(numPadLayer)) {
-    bool numState = !!(kaleidoscope::hid::getKeyboardLEDs() & LED_NUM_LOCK);
+    bool numState = getNumlockState();
     if (!cleanupDone) {
       LEDControl.set_mode(LEDControl.get_mode_index());
-      syncNumlock(false);
-      cleanupDone = true;
 
-      if (numState && !originalNumLockState) {
-        kaleidoscope::hid::pressKey(Key_KeypadNumLock);
+      if (!originalNumLockState) {
+        syncNumlock(false);
         numState = false;
       }
+      cleanupDone = true;
     }
     originalNumLockState = numState;
     return;


### PR DESCRIPTION
Test procedure:
  1. Make sure numlock is off on host machine.
  2. Activate num layer. Confirm, numlock is now on.
  3. Deactivate num layer. Confirm, numlock is now off.
  4. Using another keyboard, activate numlock on host machine.
  5. Activate num layer. Confirm, numlock is still on.
  6. Deactivate num layer. Confirm, numlock is still on.

Prior to this commit, step 6 resulted in numlock being off.

see https://github.com/keyboardio/Kaleidoscope-NumPad/pull/2
was broken https://github.com/keyboardio/Kaleidoscope-NumPad/pull/3
see https://github.com/keyboardio/Kaleidoscope-NumPad/issues/1
fixes https://github.com/keyboardio/Kaleidoscope-NumPad/issues/6