### PR TITLE
Dim the numpad color down from 255 to 160.

### DIFF
--- a/src/Kaleidoscope-NumPad.cpp
+++ b/src/Kaleidoscope-NumPad.cpp
@@ -7,7 +7,7 @@ byte NumPad_::row = 255, NumPad_::col = 255;
 uint8_t NumPad_::numPadLayer;
 bool NumPad_::cleanupDone = true;
 bool NumPad_::originalNumLockState = false;
-cRGB numpad_color = CRGB(255, 0, 0);
+cRGB numpad_color = CRGB(160, 0, 0);
 
 kaleidoscope::EventHandlerResult NumPad_::onSetup(void) {
   originalNumLockState = !!(kaleidoscope::hid::getKeyboardLEDs() & LED_NUM_LOCK);


### PR DESCRIPTION
Having it at the brightest uses too much power, and may result in power use surges when switching between LED modes and NumPad, which in turn can force the operating system to disable the whole device. To avoid this, lower the brightness to 160, a carefull tuned value, also used by the `solidRed` mode in the factory firmware.

Fixes #9.