### PR TITLE
don't avoid highlighting editing shortcuts etc

### DIFF
--- a/src/Kaleidoscope-NumPad.cpp
+++ b/src/Kaleidoscope-NumPad.cpp
@@ -58,7 +58,7 @@ kaleidoscope::EventHandlerResult NumPad_::afterEachCycle() {
         col = c;
       }
 
-      if ((k != layer_key) || (k == Key_NoKey) || (k.flags != KEY_FLAGS)) {
+      if ((k != layer_key) || (k == Key_NoKey)) {
         LEDControl.refreshAt(r, c);
       } else {
         LEDControl.setCrgbAt(r, c, color);


### PR DESCRIPTION
This plugin will only ever highlight keys which are actually intentionally placed on the NumPad layer and not any transparent keys. Avoiding highlighting keys with special flags enabled causes editing shorcuts etc that are intentionally placed on the NumPad layer to **not** be highlighted. This PR therefore proposes to remove this behaviour.