### PR TITLE
Make LED effects optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Kaleidoscope-NumPad
 
-This is a plugin for [Kaleidoscope][fw], that adds a NumPad-specific LED
-effect, along with a way to toggle to a numpad layer, and apply the effect.
+This is a plugin for [Kaleidoscope][fw] that takes care of handling the HID
+numlock toggling when switching to the numpad layer. It also adds a
+numpad-specific LED effect, which can be disabled if not desired.
 
 ## Using the extension
 
@@ -20,7 +21,7 @@ void setup() {
 }
 ```
 
-##   Plugin methods
+##   Plugin properties
 
 The plugin provides the `NumPad` object, with the following properties:
 
@@ -35,5 +36,12 @@ The plugin provides the `NumPad` object, with the following properties:
 > This property sets the color hue that the NumLock LED breathes in.
 >
 > The default is `170`, a blue hue.
+
+### `.ledEffect`
+
+> This property controls whether the above color effects are enabled or not.
+> You may wish to disable them if you simply don't want them, or if you wish to
+> use some other plugin (such as ColorMap) to handle them. Note that this plugin
+> may still be required to handle the HID numlock toggling.
 
  [fw]: https://github.com/keyboardio/Kaleidoscope

--- a/src/Kaleidoscope-NumPad.cpp
+++ b/src/Kaleidoscope-NumPad.cpp
@@ -3,10 +3,12 @@
 #include "Kaleidoscope.h"
 #include "layers.h"
 
-byte NumPad_::row = 255, NumPad_::col = 255;
+byte NumPad_::lock_row = 255, NumPad_::lock_col = 255;
 uint8_t NumPad_::numPadLayer;
 bool NumPad_::cleanupDone = true;
 bool NumPad_::originalNumLockState = false;
+
+bool NumPad_::ledEffect = true;
 cRGB NumPad_::color = CRGB(160, 0, 0);
 uint8_t NumPad_::lock_hue = 170;
 
@@ -43,6 +45,9 @@ kaleidoscope::EventHandlerResult NumPad_::afterEachCycle() {
   cleanupDone = false;
   syncNumlock(true);
 
+  if (!ledEffect)
+    return kaleidoscope::EventHandlerResult::OK;
+
   LEDControl.set_mode(LEDControl.get_mode_index());
 
   for (uint8_t r = 0; r < ROWS; r++) {
@@ -51,8 +56,8 @@ kaleidoscope::EventHandlerResult NumPad_::afterEachCycle() {
       Key layer_key = Layer.getKey(numPadLayer, r, c);
 
       if (k == LockLayer(numPadLayer)) {
-        row  = r;
-        col = c;
+        lock_row = r;
+        lock_col = c;
       }
 
       if ((k != layer_key) || (k == Key_NoKey) || (k.flags != KEY_FLAGS)) {
@@ -63,11 +68,11 @@ kaleidoscope::EventHandlerResult NumPad_::afterEachCycle() {
     }
   }
 
-  if (row > ROWS || col > COLS)
+  if (lock_row > ROWS || lock_col > COLS)
     return kaleidoscope::EventHandlerResult::OK;
 
   cRGB lock_color = breath_compute(lock_hue);
-  LEDControl.setCrgbAt(row, col, lock_color);
+  LEDControl.setCrgbAt(lock_row, lock_col, lock_color);
 
   return kaleidoscope::EventHandlerResult::OK;
 }

--- a/src/Kaleidoscope-NumPad.h
+++ b/src/Kaleidoscope-NumPad.h
@@ -9,6 +9,8 @@ class NumPad_ : public kaleidoscope::Plugin {
   NumPad_(void) {}
 
   static uint8_t numPadLayer;
+
+  static bool ledEffect;
   static cRGB color;
   static uint8_t lock_hue;
 
@@ -22,7 +24,7 @@ class NumPad_ : public kaleidoscope::Plugin {
 #endif
 
  private:
-  static byte row, col;
+  static byte lock_row, lock_col;
   static bool cleanupDone;
   static bool originalNumLockState;
 };


### PR DESCRIPTION
This plugin is (primarily, at least for me) required to handle the HID numlock toggling.

The LED effects are limited and do not provide much configurability such as to highlight the operators in a different colour etc. Adding all that to this plugin would unnecessarily complicate it and are better done separately.

Further, the interaction of these effects with other active LED effects is variable:
1. If the current LED effect is a solid colour, it gets overpainted by the NumPad colours (which is what is desired).
2. If it is Rainbow or Breathe, the rest of the keys go black (which is probably not desired).

To avoid all this I wanted to disable the colouring. I thought that merely placing the NumPad plugin before the LED effects in the `KALEIDOSCOPE_INIT_PLUGINS` would be sufficient but I find that this does not work.

Ideally the colouring functionality should be separated out into a separate LED plugin, or ColorMap may also be used to handle the colouring. However this provides a basic colouring effect which may be enough for some users. So I'm just asking for the ability to disable it if not desired.

Ref: discussion at https://community.keyboard.io/t/numpad-colouring-problems-and-turning-it-off/1844.