### PR TITLE
Limit LED refresh rate and don't update on every cycle

### DIFF
--- a/src/Kaleidoscope-NumPad.cpp
+++ b/src/Kaleidoscope-NumPad.cpp
@@ -3,12 +3,15 @@
 #include "Kaleidoscope.h"
 #include "layers.h"
 
+#define UPDATE_INTERVAL 50  // milliseconds between two LED updates to avoid overloading; 20 fps
+
 byte NumPad_::row = 255, NumPad_::col = 255;
 uint8_t NumPad_::numPadLayer;
 bool NumPad_::cleanupDone = true;
 bool NumPad_::originalNumLockState = false;
 cRGB NumPad_::color = CRGB(160, 0, 0);
 uint8_t NumPad_::lock_hue = 170;
+uint16_t NumPad_::last_update = 0;
 
 kaleidoscope::EventHandlerResult NumPad_::onSetup(void) {
   originalNumLockState = !!(kaleidoscope::hid::getKeyboardLEDs() & LED_NUM_LOCK);
@@ -45,6 +48,11 @@ kaleidoscope::EventHandlerResult NumPad_::afterEachCycle() {
 
   cleanupDone = false;
   syncNumlock(true);
+
+  uint16_t now = millis();
+  if ((now - last_update) < UPDATE_INTERVAL)
+    return kaleidoscope::EventHandlerResult::OK;
+  last_update = now;
 
   LEDControl.set_mode(LEDControl.get_mode_index());
 

--- a/src/Kaleidoscope-NumPad.h
+++ b/src/Kaleidoscope-NumPad.h
@@ -19,6 +19,7 @@ class NumPad_ : public kaleidoscope::Plugin {
   static byte row, col;
   static bool cleanupDone;
   static bool originalNumLockState;
+  static uint16_t last_update;
 };
 
 extern NumPad_ NumPad;


### PR DESCRIPTION
Setting the color of all the keys every cycle is that the numlock is on is
unnecessary. Especially breathing is not a cheap function and doesn't change
output value for every input anyway. This waste of time in refreshing LEDs is
found to cause drag in mouse movements. This commit seeks to fix this problem.

Note that the ActiveModColor plugin seems to run every cycle, so not doing the numpad update every cycle means that the breathing effect of the numlock is “overwritten” by the color imposed by that other plugin. However, that is a cosmetic problem and this (slow mouse movement) is a functional problem so this one takes precedence IMO.

Anyhow I submit this PR to draw attention to this issue.